### PR TITLE
Add AsyncDelegatedDisposalStream and AsyncDisposableDelegate

### DIFF
--- a/src/AsyncDelegatedDisposalStream.cs
+++ b/src/AsyncDelegatedDisposalStream.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OwlCore.ComponentModel;
+
+/// <summary>
+/// A <see cref="Stream"/> wrapper that, on dispose, disposes both the stream and an additional <see cref="IAsyncDisposable"/>.
+/// </summary>
+public class AsyncDelegatedDisposalStream : Stream, IDelegable<IAsyncDisposable>, IAsyncDisposable
+{
+    private readonly Stream _sourceStream;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="AsyncDelegatedDisposalStream"/>.
+    /// </summary>
+    /// <param name="sourceStream">The stream to dispose asynchronously.</param>
+    public AsyncDelegatedDisposalStream(Stream sourceStream)
+    {
+        if (sourceStream is not IAsyncDisposable)
+            throw new ArgumentException($"The provided {nameof(sourceStream)} does not implement {nameof(IAsyncDisposable)} and cannot be used with {nameof(AsyncDelegatedDisposalStream)}.");
+
+        _sourceStream = sourceStream;
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (disposing)
+        {
+            if (Inner is IDisposable disposable)
+                disposable.Dispose();
+            else
+                Inner.DisposeAsync().AsTask().Wait();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        // Perform async cleanup.
+        await Inner.DisposeAsync();
+
+        // Dispose of unmanaged resources.
+        Dispose(false);
+
+        // Suppress finalization.
+        GC.SuppressFinalize(this);
+    }
+
+    /// <inheritdoc />
+    public override void Flush() => _sourceStream.Flush();
+
+    /// <inheritdoc />
+    public override Task FlushAsync(CancellationToken cancellationToken) => _sourceStream.FlushAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public override int Read(byte[] buffer, int offset, int count) => _sourceStream.Read(buffer, offset, count);
+
+    /// <inheritdoc />
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => _sourceStream.ReadAsync(buffer, offset, count, cancellationToken);
+
+#if NET5_0_OR_GREATER
+    /// <inheritdoc />
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => _sourceStream.ReadAsync(buffer, cancellationToken);
+#endif
+
+    /// <inheritdoc />
+    public override long Seek(long offset, SeekOrigin origin) => _sourceStream.Seek(offset, origin);
+
+    /// <inheritdoc />
+    public override void SetLength(long value) => _sourceStream.SetLength(value);
+
+    /// <inheritdoc />
+    public override void Write(byte[] buffer, int offset, int count) => _sourceStream.Write(buffer, offset, count);
+
+    /// <inheritdoc />
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => _sourceStream.WriteAsync(buffer, offset, count, cancellationToken);
+
+#if NET5_0_OR_GREATER
+    /// <inheritdoc />
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => _sourceStream.WriteAsync(buffer, cancellationToken);
+#endif
+
+    /// <inheritdoc />
+    public override bool CanRead => _sourceStream.CanRead;
+
+    /// <inheritdoc />
+    public override bool CanSeek => _sourceStream.CanSeek;
+
+    /// <inheritdoc />
+    public override bool CanWrite => _sourceStream.CanWrite;
+
+    /// <inheritdoc />
+    public override long Length => _sourceStream.Length;
+
+    /// <inheritdoc />
+    public override long Position
+    {
+        get => _sourceStream.Position;
+        set => _sourceStream.Position = value;
+    }
+
+    /// <inheritdoc />
+    public required IAsyncDisposable Inner { get; init; }
+}

--- a/src/AsyncDelegatedDisposalStream.cs
+++ b/src/AsyncDelegatedDisposalStream.cs
@@ -34,7 +34,7 @@ public class AsyncDelegatedDisposalStream : Stream, IDelegable<IAsyncDisposable>
             if (Inner is IDisposable disposable)
                 disposable.Dispose();
             else
-                Inner.DisposeAsync().AsTask().Wait();
+                Inner.DisposeAsync().AsTask().GetAwaiter().GetResult();
         }
     }
 

--- a/src/AsyncDelegatedDisposalStream.cs
+++ b/src/AsyncDelegatedDisposalStream.cs
@@ -15,7 +15,7 @@ public class AsyncDelegatedDisposalStream : Stream, IDelegable<IAsyncDisposable>
     /// <summary>
     /// Creates a new instance of <see cref="AsyncDelegatedDisposalStream"/>.
     /// </summary>
-    /// <param name="sourceStream">The stream to dispose asynchronously.</param>
+    /// <param name="sourceStream">The stream to wrap. Must implement <see cref="IAsyncDisposable"/>.</param>
     public AsyncDelegatedDisposalStream(Stream sourceStream)
     {
         if (sourceStream is not IAsyncDisposable)
@@ -104,6 +104,8 @@ public class AsyncDelegatedDisposalStream : Stream, IDelegable<IAsyncDisposable>
         set => _sourceStream.Position = value;
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// The additional <see cref="IAsyncDisposable"/> instance that will be disposed along with the stream.
+    /// </summary>
     public required IAsyncDisposable Inner { get; init; }
 }

--- a/src/AsyncDelegatedDisposalStream.cs
+++ b/src/AsyncDelegatedDisposalStream.cs
@@ -31,6 +31,9 @@ public class AsyncDelegatedDisposalStream : Stream, IDelegable<IAsyncDisposable>
 
         if (disposing)
         {
+            // Dispose the source stream synchronously
+            _sourceStream.Dispose();
+
             if (Inner is IDisposable disposable)
                 disposable.Dispose();
             else
@@ -43,6 +46,10 @@ public class AsyncDelegatedDisposalStream : Stream, IDelegable<IAsyncDisposable>
     {
         // Perform async cleanup.
         await Inner.DisposeAsync();
+
+        // Dispose the source stream asynchronously if it supports it
+        if (_sourceStream is IAsyncDisposable asyncDisposableStream)
+            await asyncDisposableStream.DisposeAsync();
 
         // Dispose of unmanaged resources.
         Dispose(false);

--- a/src/AsyncDisposableDelegate.cs
+++ b/src/AsyncDisposableDelegate.cs
@@ -4,12 +4,12 @@ using System.Threading.Tasks;
 namespace OwlCore.ComponentModel;
 
 /// <summary>
-/// An implementation of <see cref="IDisposable"/> that calls an <see cref="Func{Task}"/> when disposed.
+/// An implementation of <see cref="IAsyncDisposable"/> that calls an <see cref="Func{Task}"/> when disposed.
 /// </summary>
 public sealed class AsyncDisposableDelegate : IAsyncDisposable, IDelegable<Func<Task>>
 {
     /// <summary>
-    /// The inner <see cref="Action"/> that is invoked when <see cref="IDisposable.Dispose"/> is called.
+    /// The inner <see cref="Func{Task}"/> that is invoked when <see cref="IAsyncDisposable.DisposeAsync"/> is called.
     /// </summary>
     public required Func<Task> Inner { get; init; }
 

--- a/src/AsyncDisposableDelegate.cs
+++ b/src/AsyncDisposableDelegate.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+
+namespace OwlCore.ComponentModel;
+
+/// <summary>
+/// An implementation of <see cref="IDisposable"/> that calls an <see cref="Func{Task}"/> when disposed.
+/// </summary>
+public sealed class AsyncDisposableDelegate : IAsyncDisposable, IDelegable<Func<Task>>
+{
+    /// <summary>
+    /// The inner <see cref="Action"/> that is invoked when <see cref="IDisposable.Dispose"/> is called.
+    /// </summary>
+    public required Func<Task> Inner { get; init; }
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => new ValueTask(Inner());
+}

--- a/src/OwlCore.ComponentModel.csproj
+++ b/src/OwlCore.ComponentModel.csproj
@@ -24,7 +24,7 @@
 --- 0.10.0 ---
 [New]
 Added AsyncDelegatedDisposalStream, a Stream wrapper that disposes both the underlying stream and an additional IAsyncDisposable when disposed. This class enforces that the wrapped stream implements IAsyncDisposable and delegates all standard stream operations to the source stream.
-Introduced AsyncDisposableDelegate, a class that implements IAsyncDisposable and allows specifying a custom asynchronous disposal callback via a Func<Task>
+Introduced AsyncDisposableDelegate, a class that implements IAsyncDisposable and allows specifying a custom asynchronous disposal callback via a Func{Task}
 
 
 --- 0.9.1 ---
@@ -132,7 +132,7 @@ All public and protected methods in SettingsBase are now virtual.
 --- 0.0.0 ---
 [New]
 Initial separated package release of OwlCore.ComponentModel. Transferred from OwlCore 0.1.0.
-		</PackageReleaseNotes>
+    </PackageReleaseNotes>
     <DebugType>embedded</DebugType>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Arlo Godfrey</Authors>

--- a/src/OwlCore.ComponentModel.csproj
+++ b/src/OwlCore.ComponentModel.csproj
@@ -14,13 +14,19 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.9.1</Version>
+    <Version>0.10.0</Version>
     <Product>OwlCore</Product>
     <Description>Provides classes that are used to implement the run-time behavior of components.</Description>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageIcon>logo.png</PackageIcon>
     <PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.ComponentModel</PackageProjectUrl>
     <PackageReleaseNotes>
+--- 0.10.0 ---
+[New]
+Added AsyncDelegatedDisposalStream, a Stream wrapper that disposes both the underlying stream and an additional IAsyncDisposable when disposed. This class enforces that the wrapped stream implements IAsyncDisposable and delegates all standard stream operations to the source stream.
+Introduced AsyncDisposableDelegate, a class that implements IAsyncDisposable and allows specifying a custom asynchronous disposal callback via a Func<Task>
+
+
 --- 0.9.1 ---
 [Improvements]
 Complete internal refactor of LazySeekStream with a focus on tracking witten byte ranges and redirecting reads to backing as needed.


### PR DESCRIPTION
This pull request introduces two new classes that enhance asynchronous disposal capabilities in the `OwlCore.ComponentModel` namespace. These additions provide more flexible and composable ways to manage resource cleanup, especially for scenarios requiring asynchronous disposal logic.

### New asynchronous disposal utilities

* Added `AsyncDelegatedDisposalStream`, a `Stream` wrapper that disposes both the underlying stream and an additional `IAsyncDisposable` when disposed. This class enforces that the wrapped stream implements `IAsyncDisposable` and delegates all standard stream operations to the source stream. (`src/AsyncDelegatedDisposalStream.cs`)
* Introduced `AsyncDisposableDelegate`, a class that implements `IAsyncDisposable` and allows specifying a custom asynchronous disposal callback via a `Func<Task>`. (`src/AsyncDisposableDelegate.cs`)