### PR TITLE
Add net9.0 target framework, condition async compat packages for net10.0+

### DIFF
--- a/src/OwlCore.ComponentModel.csproj
+++ b/src/OwlCore.ComponentModel.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>11.0</LangVersion>
     <WarningsAsErrors>nullable</WarningsAsErrors>
@@ -166,13 +166,13 @@ Initial separated package release of OwlCore.ComponentModel. Transferred from Ow
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="PolySharp" Version="1.14.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds `net9.0` to the `TargetFrameworks` list alongside the existing `netstandard2.0;net8.0;net10.0` targets.

`System.Linq.Async` and `Microsoft.Bcl.AsyncInterfaces` are now conditioned with `!IsTargetFrameworkCompatible('\$(TargetFramework)', 'net10.0')` so they are excluded on net10.0+ where these APIs are built into the runtime.

No version bump in this PR.