### PR TITLE
Release 0.11.0

### DIFF
--- a/src/OwlCore.ComponentModel.csproj
+++ b/src/OwlCore.ComponentModel.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>11.0</LangVersion>
     <WarningsAsErrors>nullable</WarningsAsErrors>
@@ -166,13 +166,13 @@ Initial separated package release of OwlCore.ComponentModel. Transferred from Ow
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="PolySharp" Version="1.14.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.3.1" />
   </ItemGroup>
 

--- a/src/OwlCore.ComponentModel.csproj
+++ b/src/OwlCore.ComponentModel.csproj
@@ -14,13 +14,17 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <Author>Arlo Godfrey</Author>
-    <Version>0.10.1</Version>
+    <Version>0.11.0</Version>
     <Product>OwlCore</Product>
     <Description>Provides classes that are used to implement the run-time behavior of components.</Description>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageIcon>logo.png</PackageIcon>
     <PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.ComponentModel</PackageProjectUrl>
     <PackageReleaseNotes>
+--- 0.11.0 ---
+[Improvements]
+Added net9.0 as a target framework. System.Linq.Async and Microsoft.Bcl.AsyncInterfaces are now conditioned to exclude net10.0+, where these APIs are built into the runtime.
+
 --- 0.10.1 ---
 [Improvements]
 Refactored LazySeekStream to no longer require the underlying source stream to have a known Length.


### PR DESCRIPTION
Bumps version `0.10.1` → `0.11.0` and adds release notes.

Depends on #10 merging first.